### PR TITLE
feat: Python依存を廃止し、PHPのみでスクレイピングを完結

### DIFF
--- a/lib/exec_chromedriver.php
+++ b/lib/exec_chromedriver.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * 但馬牛血統証明システムから情報を取得し、CSV用配列に整形する
+ * Python依存なし、PHPのみで完結
+ **/
 function getCowData($idNumbers) {
 	if ($idNumbers) {
 		$csvs = array();
@@ -11,13 +15,9 @@ function getCowData($idNumbers) {
 			$cache_file = dirname(__DIR__). '/lib/exec_chromedriver/cache/'. $idNumber. '.html';
 			if (!file_exists($cache_file) || (filectime($cache_file) > strtotime('+1 month')) || (filesize($cache_file) <= 0) || (checkValues($cache_file) == false)) {
 				echo '+1 month data gathering process...<br>';
-				touch($cache_file);
-				$execFile = dirname(__DIR__). '/lib/exec_chromedriver/tajima_cow.py';
-				$execCmd = sprintf("python3 %s %s 2>&1", $execFile, escapeshellarg($idNumber));
-				echo shell_exec($execCmd);
+				fetchAndCache($idNumber, $cache_file);
 				sleep(1);
-				$cache_data = file_get_contents($cache_file);
-				$r_contents = $cache_data;
+				$r_contents = file_get_contents($cache_file);
 			} else {
 				$r_contents = file_get_contents($cache_file);
 			}
@@ -78,6 +78,44 @@ function getCowData($idNumbers) {
 		}
 		return array('csvs' => $csvs, 'csvsAr' => $csvsAr);
 	}
+}
+
+/**
+ * 対象サイトにPOSTリクエストを送信し、取得したHTMLをcacheファイルに保存
+ **/
+function fetchAndCache($idNumber, $cache_file) {
+	$url = 'http://www.tajimagyu-trace.com/trace_back.php';
+	$post_data = array(
+		'__EVENTTARGET' => 'submit_search',
+		'__EVENTARGUMENT' => '',
+		'id_number' => $idNumber,
+		'trc_agreement' => '',
+	);
+
+	$context = stream_context_create(array(
+		'http' => array(
+			'method' => 'POST',
+			'header' => 'Content-Type: application/x-www-form-urlencoded',
+			'content' => http_build_query($post_data),
+			'timeout' => 30,
+		),
+	));
+
+	$response = @file_get_contents($url, false, $context);
+	if ($response === false) {
+		return;
+	}
+
+	// euc-jp → UTF-8 変換
+	$html = mb_convert_encoding($response, 'UTF-8', 'EUC-JP');
+
+	// cacheディレクトリがなければ作成
+	$cache_dir = dirname($cache_file);
+	if (!is_dir($cache_dir)) {
+		mkdir($cache_dir, 0755, true);
+	}
+
+	file_put_contents($cache_file, $html);
 }
 
 /**


### PR DESCRIPTION
## 概要

Python（requests）への依存を廃止し、PHPのみでHTTPリクエスト・HTML取得を完結させる。

## 背景

- 本番さくらサーバーにPython 3が入っていない（Python 2.7のみ）
- やっていることはPOSTリクエストでHTMLを取得してファイルに保存するだけなので、PHPの`file_get_contents`で十分

## 変更内容

### exec_chromedriver.php
- `fetchAndCache()` 関数を新規追加（PHPでPOSTリクエスト送信・euc-jp→UTF-8変換・cache保存）
- Python（`shell_exec`）の呼び出しを廃止
- `tajima_cow.py` は不要になるが、ファイル自体は残置（別途削除可）

## テスト手順
サーバーでgit pull後、キャッシュを削除して再検索