### PR TITLE
fix: EUC-JPeucJP-winに変更し㈱等のNEC特殊文字の文字化けを修正

### DIFF
--- a/lib/exec_chromedriver.php
+++ b/lib/exec_chromedriver.php
@@ -106,8 +106,8 @@ function fetchAndCache($idNumber, $cache_file) {
 		return;
 	}
 
-	// euc-jp → UTF-8 変換
-	$html = mb_convert_encoding($response, 'UTF-8', 'EUC-JP');
+	// euc-jp → UTF-8 変換（eucJP-win で㈱等のNEC特殊文字に対応）
+	$html = mb_convert_encoding($response, 'UTF-8', 'eucJP-win');
 
 	// cacheディレクトリがなければ作成
 	$cache_dir = dirname($cache_file);


### PR DESCRIPTION
## 概要

`fetchAndCache()` の文字コード変換で `EUC-JP` を使用していたため、「㈱」等のNEC特殊文字が `?` に変換されてしまう問題を修正。

## 原因

- PHPの `mb_convert_encoding` で `EUC-JP` を指定すると、JIS X 0208 の範囲のみ対応
- 「㈱」（U+3231）はNEC特殊文字領域（0x8740〜0x879C）にあり、`EUC-JP` では変換不可
- 以前のSelenium方式ではブラウザが内部でUnicodeデコードしていたため問題が顕在化しなかった

## 修正内容

`mb_convert_encoding` の変換元エンコーディングを `EUC-JP` → `eucJP-win` に変更。

`eucJP-win` はNEC特殊文字、NEC選定IBM拡張文字、IBM拡張文字の全領域をカバーするため、㈱・㈲・丸数字・ローマ数字等の拡張文字も正しくUTF-8に変換される。

## 備考

- 既にキャッシュ済みで `?` が保存されているファイルは、キャッシュ削除後に再取得が必要