### PR TITLE
fix: &nbsp;置換ロジックをSVN版の2段階処理に修正

### DIFF
--- a/lib/exec_chromedriver.php
+++ b/lib/exec_chromedriver.php
@@ -144,13 +144,17 @@ function setArray($array_name, $output) {
 
 		if (!empty($out)) {
 			if ($array_name === 'values') {
-				// values: &nbsp(セミコロンあり/なし)を _ に置換して後でexplodeで分割
-				$ret = preg_replace('/&nbsp;?/', '_', $out[1]);
-				// _のみの文字列（spacer等）は除外
+				// values: 2段階で&nbsp;を処理（SVN版の仕様を踏襲）
+				// ※ 意図: 連続する&nbsp;はセパレータ（市町村と名前の区切り等）なので _ に変換
+				//          単独の&nbsp;は単なるスペーサーなので除去
+				// Stage1: 2個以上連続する &nbsp;? → _ 1つ（セパレータとして使用）
+				$ret = preg_replace('/(&nbsp;?){2,}/', '_', $out[1]);
+				// Stage2: 残った単独の &nbsp;? → 除去（単なるスペーサー）
+				$ret = preg_replace('/&nbsp;?/', '', $ret);
 				$ret = trim($ret, '_');
 				$ret = trim($ret);
 			} else {
-				// charts等: &nbsp; を単純に除去
+				// charts等: &nbsp;? を単純に除去
 				$ret = preg_replace('/&nbsp;?/', '', $out[1]);
 				$ret = trim($ret);
 			}


### PR DESCRIPTION
## 概要

`setArray()` 関数の `&nbsp;` 置換ロジックが、2/26のリファクタリング時にSVN版の2段階処理から1段階処理に簡略化されてしまい、アンダーバーが過剰に出力される不具合を修正します。

## 問題

`&nbsp;` が個別に `_` へ変換されるため、本来セパレータとして `_` 1つになるべき箇所にアンダーバーが複数出力されていました。

## 原因

リファクタリング時に、SVN版の2段階処理が1つの正規表現 `/&nbsp;?/` → `_` にまとめられた結果、すべての `&nbsp;` が個別に `_` に変換されるようになっていました。

## 修正内容

SVN版の2段階ロジックを復元し、`&nbsp`（セミコロンなし）にも対応：

1. Stage1: 2個以上連続する `&nbsp;?` → `_` 1つ（市町村と名前の区切り等のセパレータ）
2. Stage2: 残った単独の `&nbsp;?` → 除去（単なるスペーサー）

各段階の意図をコメントで明記し、今後のリファクタリング時に仕様が消失しないようにしました。

## 確認事項

- [ ] デプロイ後、該当キャッシュファイルを削除して再取得し、表示を確認すること