### PR TITLE
セミコロンなしの&nbspにも対応（PHP取得時の生HTML対応）

### DIFF
--- a/lib/exec_chromedriver.php
+++ b/lib/exec_chromedriver.php
@@ -32,7 +32,7 @@ function getCowData($idNumbers) {
 			if (empty($sex)) {
 				preg_match('/(.*)Steer/', $html, $sex);
 			}
-			$sex = preg_replace('/&nbsp;|\t/', '', $sex[1]);
+			$sex = preg_replace('/&nbsp;?|\t/', '', $sex[1]);
 
 			if (!empty($arr['values'][5])) {
 				$hanshoku = explode('_', $arr['values'][5]);
@@ -138,8 +138,9 @@ function setArray($array_name, $output) {
 		}
 
 		if (!empty($out)) {
-			$ret = preg_replace('/&nbsp;&nbsp;/', '_', $out[1]);
-			$ret = preg_replace('/&nbsp;/', '', $ret);
+			// &nbsp（セミコロンなし）と &nbsp;（セミコロン付き）の両方に対応
+			$ret = preg_replace('/(&nbsp;?){2,}/', '_', $out[1]);
+			$ret = preg_replace('/&nbsp;?/', '', $ret);
 
 			if(!empty($ret)) {
 				$arr[] = $ret;
@@ -171,7 +172,7 @@ function checkValues($cache_file = null) {
 	if (empty($sex)) {
 		preg_match('/(.*)Steer/', $html, $sex);
 	}
-	$sex = preg_replace('/&nbsp;|\t/', '', $sex[1]);
+	$sex = preg_replace('/&nbsp;?|\t/', '', $sex[1]);
 
 	if (!empty($arr['values'][5])) {
 		$hanshoku = explode('_', $arr['values'][5]);


### PR DESCRIPTION
## 概要

元サイトのHTMLに含まれる `&nbsp`（セミコロンなし）が処理されず、そのまま表示される問題を修正しました。

## 原因

SVN版はSelenium（ブラウザ）経由でHTMLを取得していたため、ブラウザが `&nbsp`（セミコロンなし）もスペースに変換していました。
PHP版の `file_get_contents` は生HTMLを取得するため、セミコロンなしの `&nbsp` がリテラル文字列のまま残り、既存の正規表現 `/&nbsp;/` にマッチしませんでした。

## 修正内容

- setArray: `&nbsp;?`（セミコロンをオプショナル）に変更し、両方の表記に対応
- getCowData/checkValues内の$sex処理: 同様に `&nbsp;?` に変更